### PR TITLE
Don't return 404 template on a 404 response.

### DIFF
--- a/lib/views.js
+++ b/lib/views.js
@@ -391,7 +391,7 @@ bedrock.events.on(
           if(res.statusCode === 403) {
             res.render('error-403.html', vars);
           } else if(res.statusCode === 404) {
-            res.render('error-404.html', vars);
+            res.render('main.html', vars);
           } else if(res.statusCode === 503) {
             res.render('error-503.html', vars);
           } else {


### PR DESCRIPTION
This is a relic of how we used to do views. Now, we let the front-end application
handle 404 errors, so it can render them however it would like to instead of
only displaying a generic 404.

Note that we'll need to update the rest of our views code in the future, a lot of it is pretty ancient and is very unfriendly towards how we do SPA applications.
