### PR TITLE
Update minimum browser versions.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -129,11 +129,11 @@ config.views.paths = [
 ];
 
 config.views.browserVersions = {
-  IE: {major: 8, minor: 0},
-  Firefox: {major: 3, minor: 6},
-  Opera: {major: 10, minor: 6},
-  Safari: {major: 4, minor: 0},
-  Chrome: {major: 17, minor: 0}
+  IE: {major: 11, minor: 0},
+  Firefox: {major: 28, minor: 0},
+  Opera: {major: 12, minor: 1},
+  Safari: {major: 6, minor: 1},
+  Chrome: {major: 29, minor: 0}
 };
 
 config.views.vars = {


### PR DESCRIPTION
This patch updates various versions and may need more thought and work.

The versions are used by server side UA detection to set a flag that puts up a "update your browser" warning.  We want to be as loose as possible.

The updated versions here are initially based on http://caniuse.com/#search=flexbox.  What else should we use to determine minimum versions?  Is using flexbox as a baseline an issue for some apps that might not use it?

This list may also need to be updated to specifically list mobile browsers too.

A more complex system constraint system would let modules specify what features and/or minimum browser versions they need and something like the code here would combine all that into one main check.  I think for now we'll just have to update these versions as we start using newer browser features.