### PR TITLE
Move supported user agent support to server.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Changed
 - **BREAKING**: Remove prefixes from html element.
 - Move supported user agent check to server side template from bedrock-angular.
+- Remove no-javascript warning.
 
 ## 4.5.0 - 2017-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - **BREAKING**: Remove prefixes from html element.
 - Move supported user agent check to server side template from bedrock-angular.
 - Remove no-javascript warning.
+- Return 404 when requesting modules that are not found.
 
 ## 4.5.0 - 2017-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # bedrock-views ChangeLog
 
+### Changed
+- Move supported user agent check to server side template from bedrock-angular.
+
 ## 4.5.0 - 2017-05-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # bedrock-views ChangeLog
 
 ### Changed
+- **BREAKING**: Remove prefixes from html element.
 - Move supported user agent check to server side template from bedrock-angular.
 
 ## 4.5.0 - 2017-05-02

--- a/lib/views.js
+++ b/lib/views.js
@@ -21,6 +21,31 @@ const logger = bedrock.loggers.get('app');
 // set the default timezone offset for the template system
 swigcore.setDefaultTZOffset(0);
 
+function _userAgent(req) {
+  const state = req['bedrock-views'] = req['bedrock-views'] || {};
+  if(!state.userAgent) {
+    state.userAgent = uaParser.parse(req.headers['user-agent'] || '');
+  }
+  return state.userAgent;
+}
+
+function _hasSupportedUserAgent(req) {
+  const state = req['bedrock-views'] = req['bedrock-views'] || {};
+  if(!('supportedUserAgent' in state)) {
+    // detect obsolete browsers
+    const ua = _userAgent(req);
+    state.supportedUserAgent = true;
+    if(ua.family in bedrock.config.views.browserVersions) {
+      const version = bedrock.config.views.browserVersions[ua.family];
+      if(ua.major < version.major ||
+        (ua.major === version.major && ua.minor < version.minor)) {
+        state.supportedUserAgent = false;
+      }
+    }
+  }
+  return state.supportedUserAgent;
+}
+
 /**
  * Gets a copy of the default view variables.
  *
@@ -30,8 +55,11 @@ swigcore.setDefaultTZOffset(0);
 api.getDefaultViewVars = function(req, callback) {
   var vars = bedrock.util.clone(bedrock.config.views.vars);
 
-  // include browser user agent
-  vars.userAgent = req.userAgent;
+  // get parsed user agent data
+  vars.userAgent = () => _userAgent(req);
+
+  // check if user agent supported
+  vars.hasSupportedUserAgent = () => _hasSupportedUserAgent(req);
 
   // converts a var to json for later JSON.parse() via a page script
   vars.parsify = function(v) {
@@ -51,25 +79,6 @@ api.getDefaultViewVars = function(req, callback) {
     callback(err, vars);
   });
 };
-
-bedrock.events.on('bedrock-express.configure.static', (app, callback) => {
-  // early handler to detect obsolete browsers
-  app.use((req, res, next) => {
-    const ua = req.userAgent = uaParser.parse(req.headers['user-agent'] || '');
-    ua.obsolete = false;
-    if(ua.family in bedrock.config.views.browserVersions) {
-      const version = bedrock.config.views.browserVersions[ua.family];
-      if(ua.major < version.major ||
-        (ua.major === version.major && ua.minor < version.minor)) {
-        ua.obsolete = true;
-      }
-    }
-    bedrock.config.views.vars.userAgent = ua;
-    next();
-  });
-
-  callback();
-});
 
 bedrock.events.on('bedrock-express.configure.routes', configure);
 

--- a/lib/views.js
+++ b/lib/views.js
@@ -127,6 +127,13 @@ function configure(app) {
     return;
   }
 
+  // return 404 for unknown modules
+  app.get(
+    bedrock.config.views.system.config.baseURL + '*', (req, res, next) => {
+    res.status(404);
+    next();
+  });
+
   /* Build basic routes from the config.
 
   The routes config value is an array. Each route value is a string that

--- a/views/layout.html
+++ b/views/layout.html
@@ -68,13 +68,11 @@
   {% else %}
   <body>
     {% block unsupportedUserAgent %}
-    <div class="container">
-      <div class="alert alert-danger">
-        Your browser
-        ({{userAgent().family}} {{userAgent().major}}.{{userAgent().minor}}.{{userAgent().patch}})
-        is <strong>out of date</strong> and unable to display this site.
-        Please <a href="http://www.updateyourbrowser.net/">update your browser.</a>
-      </div>
+    <div>
+      Your browser
+      ({{userAgent().family}} {{userAgent().major}}.{{userAgent().minor}}.{{userAgent().patch}})
+      is <strong>out of date</strong> and unable to display this site.
+      Please <a href="http://www.updateyourbrowser.net/">update your browser.</a>
     </div>
     {% endblock %}
   </body>

--- a/views/layout.html
+++ b/views/layout.html
@@ -39,13 +39,6 @@
   <body class="{{(app.ngClass.body && '') || 'br-body'}}"
     ng-class="app.ngClass.body"
     ng-style="app.ngStyle.body" ng-cloak>
-    <!-- Javascript warning -->
-    <noscript>
-      <div class="alert alert-danger">
-        <p>Javascript must be enabled to use this site.</p>
-      </div>
-    </noscript>
-
     {% if pageLayout != "error" %}
     {% block forcedFonts %}{% endblock %}
     {% endif %}

--- a/views/layout.html
+++ b/views/layout.html
@@ -44,6 +44,7 @@
     {% endif %}
   </head>
 
+  {% if hasSupportedUserAgent() %}
   <body class="{{(app.ngClass.body && '') || 'br-body'}}"
     ng-class="app.ngClass.body"
     ng-style="app.ngStyle.body" ng-cloak>
@@ -64,4 +65,18 @@
     <br-app></br-app>
     {% endblock %}
   </body>
+  {% else %}
+  <body>
+    {% block unsupportedUserAgent %}
+    <div class="container">
+      <div class="alert alert-danger">
+        Your browser
+        ({{userAgent().family}} {{userAgent().major}}.{{userAgent().minor}}.{{userAgent().patch}})
+        is <strong>out of date</strong> and unable to display this site.
+        Please <a href="http://www.updateyourbrowser.net/">update your browser.</a>
+      </div>
+    </div>
+    {% endblock %}
+  </body>
+  {% endif %}
 </html>

--- a/views/layout.html
+++ b/views/layout.html
@@ -1,14 +1,5 @@
 <!DOCTYPE html>
-<html prefix="
-  {% block prefixes %}
-  xsd: http://www.w3.org/2001/XMLSchema#
-  rdfs: http://www.w3.org/2000/01/rdf-schema#
-  dc: http://purl.org/dc/terms/
-  br: https://w3id.org/bedrock#
-  sec: https://w3id.org/security#
-  vcard: http://www.w3.org/2006/vcard/ns#
-  {% endblock %}" {% block headAttrs %}{% endblock %}>
-
+<html {% block headAttrs %}{% endblock %}>
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />


### PR DESCRIPTION
- Avoid parsing user agent for every static resource.
- Only parse UA once on demand in top level layout.
- Cache parsed UA results in req.
- Move runtime browser warning to server side rendering.