### PR TITLE
Add ability to specify browser dependencies in manifest overrides.

### DIFF
--- a/lib/packages.js
+++ b/lib/packages.js
@@ -59,6 +59,7 @@ api.readPackagesSync = rootModule => {
   const pseudoPkgs = bedrock.config.views.system.packages;
   for(const pseudoPkg of pseudoPkgs) {
     const pkg = _readPackageSync(rootModule, _packageCache, pseudoPkg);
+    logger.verbose(`Processing pseudo package "${pkg.manifest.name}"`, pkg);
     _packageCache[pkg.manifest.name] = pkg;
   }
 
@@ -335,6 +336,7 @@ function _readPackageSync(moduleName, cache, pseudoPkg) {
 }
 
 function _readDependenciesSync(pkg, cache) {
+  logger.debug(`Reading dependencies for package "${pkg.manifest.name}"`);
   if(!cache) {
     cache = _packageCache;
   }
@@ -410,15 +412,17 @@ function _sortPackages(cache) {
 function _getBrowserDependencies(pkg) {
   // `bedrock.browserDependencies` must be defined to automatically pull in
   // browser dependencies
-  if(!(pkg.manifest.bedrock && pkg.manifest.bedrock.browserDependencies)) {
-    return [];
-  }
-
-  let deps = pkg.manifest.bedrock.browserDependencies;
+  let deps = _.get(pkg, 'manifest.bedrock.browserDependencies', []);
   if(deps === 'all') {
     // special value of `all` means use `pkg.manifest.dependencies`
     deps = Object.keys(pkg.manifest.dependencies || {});
   }
+
+  // search for additional dependencies in manifest overrides
+  const overrides = _.get(pkg, 'manifest.bedrock.manifest', {});
+  Object.keys(overrides).filter(key => overrides[key].browserDependencies)
+    .forEach(key => deps = deps.concat(overrides[key].browserDependencies));
+
   return deps;
 }
 
@@ -427,6 +431,7 @@ function _getManifestOverride(pkgCache, pkgName) {
   if(!(pkg.manifest.bedrock && pkg.manifest.bedrock.manifest)) {
     return {};
   }
+  logger.debug(`Applying manifest overrides defined in ${pkg.manifest.name}`);
   const overrides = {};
   Object.keys(pkg.manifest.bedrock.manifest).forEach(k => {
     // only include override if it overrides an existing package in the cache


### PR DESCRIPTION
See https://github.com/digitalbazaar/bedrock-protractor/blob/systemjs/package.json#L51 for an example of usage of this new feature.

Manifest overrides are processed *after* the full dependency list has been created.  This patch is required to add dependencies earlier in the process.