### PR TITLE
Fix bug that prevented disabling default views behavior.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-views ChangeLog
 
+## 6.5.1 - 2019-10-xx
+
+### Fixed
+- Fix bug that preventing overriding default views behavior.
+
 ## 6.5.0 - 2019-03-05
 
 ### Added

--- a/lib/views.js
+++ b/lib/views.js
@@ -192,7 +192,7 @@ bedrock.events.on('bedrock-express.start', function(app, callback) {
   // handler is attached (or cancel its attachment)
   bedrock.events.emit('bedrock-views.add', function(err, result) {
     if(err || result === false) {
-      return callback(err, result);
+      return callback(err);
     }
 
     // add "not found"/default handler now that all other routes are configured


### PR DESCRIPTION
The `callback` that is being called here is for `bedrock-express.start`. If the `bedrock-views.add` event is canceled, it should only cancel the default behavior for that event, it should NOT cancel `bedrock-express.start`. Therefore, we should not be passing `result` to `callback`.