### PR TITLE
Remove `consolidate` and config for built-in server-side templates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
   package such as `@bedrock/webpack` and `config.views.bundle` provides
   configuration hooks for this. Only `config.views.main` remains as a point
   of configuration for the main view.
+- **BREAKING**: Remove obsolete feature to specify a `bedrock` section in
+  package.json that causes overrides in how the package is imported. This
+  has been replaced by specifying webpack configuration rules as needed.
 
 ## 11.1.0 - 2024-02-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@
   the application author's CSRF-protection middleware package of choice that
   will, e.g., inject a CSRF cookie with a value that must match one that is
   included in the POST data.
+- **BREAKING**: Remove `consolidate` dependency for generating server-side
+  templates and the related configuration variables `config.views.engine` and
+  `config.views.paths`. Any processing or bundling of frontend application
+  code (whether server-side or client-side) is to be performed via another
+  package such as `@bedrock/webpack` and `config.views.bundle` provides
+  configuration hooks for this. Only `config.views.main` remains as a point
+  of configuration for the main view.
 
 ## 11.1.0 - 2024-02-28
 

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -15,7 +15,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as bedrock from '@bedrock/core';
 import * as packages from './packages.js';
 import {logger} from './logger.js';
@@ -68,11 +67,6 @@ bedrock.events.on('bedrock-cli.ready', async () => {
   const command = bedrock.config.cli.command;
   if(command.name() === 'bundle') {
     await bedrock.runOnce('bedrock-views.bundle', async () => {
-      // load any bedrock configs for packages
-      const pkgs = await packages.readPackages();
-      await Promise.all(Object.values(pkgs).map(
-        async pkg => pkg.requireBedrockConfig()));
-
       try {
         await _bundle({optimize: isProduction});
       } catch(err) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -15,7 +15,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as bedrock from '@bedrock/core';
 import {fileURLToPath} from 'node:url';
 import path from 'node:path';
@@ -29,14 +28,6 @@ const {config} = bedrock;
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 config.views = {};
-
-// render config
-// any consolidate.js engine can be used as long as proper lib is installed.
-config.views.engine = 'lodash';
-// paths to search for views
-config.views.paths = [
-  path.join(__dirname, '..', 'views')
-];
 
 // frontend main HTML config
 config.views.main = {

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -19,7 +19,6 @@
 import * as bedrock from '@bedrock/core';
 import {createRequire} from 'node:module';
 import fs from 'node:fs';
-import {klona} from 'klona';
 import {logger} from './logger.js';
 import path from 'node:path';
 import '@bedrock/express';
@@ -57,7 +56,7 @@ export async function readPackages(rootModule) {
 
   // return cached packages
   if(_packageCache && _rootModule === rootModule) {
-    return klona(_packageCache);
+    return structuredClone(_packageCache);
   }
 
   logger.debug('Reading browser packages for "' + rootModule + '"...');
@@ -226,46 +225,6 @@ async function _readPackage({moduleName, cache, pseudoPkg, paths = null}) {
   } catch(e) {
     logger.warning('Could not read package for ' + moduleName, e);
     return null;
-  }
-
-  // TODO: remove `bedrock config`, if possible... potentially use `config`
-  // which is official in `package.json` ... or nothing at all
-
-  // require the bedrock config from the package, if possible
-  pkg.requireBedrockConfig = async function() {
-    if(!pkg.bedrock || !pkg.bedrock.config) {
-      return false;
-    }
-    // FIXME: document the purpose and usage of these dependencies
-    // ensure dependencies are met before loading config
-    const deps = pkg.bedrock.dependencies || {};
-    for(const dep in deps) {
-      // TODO: check version as well
-      if(!(dep in cache)) {
-        logger.warning('bedrock.json dependency not found: "' +
-          dep + '" for package: "' + pkg.manifest.name + '"');
-        return false;
-      }
-    }
-    const files = [].concat(pkg.bedrock.config);
-    for(const file of files) {
-      const api = await import(path.resolve(pkg.path, file));
-      (api.default || api)(bedrock);
-    }
-    return true;
-  };
-
-  // load bedrock.json
-  const filename = path.resolve(pkg.path, 'bedrock.json');
-  if(!fs.existsSync(filename)) {
-    return pkg;
-  }
-  try {
-    pkg.bedrock = await _readJsonFile(filename);
-  } catch(e) {
-    logger.warning('Could not read "bedrock.json" from package ' +
-      '"' + pkg.manifest.name + '"', e);
-    return pkg;
   }
 
   logger.verbose('Read package for ' + moduleName + ':\n' +

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -15,7 +15,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as bedrock from '@bedrock/core';
 import {createRequire} from 'node:module';
 import fs from 'node:fs';

--- a/lib/views.js
+++ b/lib/views.js
@@ -16,7 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as bedrock from '@bedrock/core';
-import consolidate from 'consolidate';
 import {middleware} from '@bedrock/express';
 import path from 'node:path';
 
@@ -44,21 +43,6 @@ function _whenNotHtml(req, res, next) {
 function _sendMainHtml(req, res) {
   res.sendFile(mainHtmlFilePath, bedrock.config.views.main.file.options);
 }
-
-// configure template engine and add routes from config
-bedrock.events.on('bedrock-express.configure.routes', function(app) {
-  // setup views
-  let viewPaths = bedrock.config.views.paths;
-  if(!Array.isArray(viewPaths)) {
-    viewPaths = [viewPaths];
-  }
-  const paths = viewPaths.map(p => path.resolve(p));
-
-  // add the default template engine
-  app.engine('html', consolidate[bedrock.config.views.engine]);
-  app.set('view engine', 'html');
-  app.set('views', paths);
-});
 
 bedrock.events.on('bedrock.init', () => {
   // store the location, in-memory, for the webpack generated index.html file

--- a/package.json
+++ b/package.json
@@ -25,9 +25,7 @@
   },
   "homepage": "https://github.com/digitalbazaar/bedrock-views",
   "dependencies": {
-    "consolidate": "^0.16.0",
-    "klona": "^2.0.5",
-    "lodash": "^4.17.21"
+    "klona": "^2.0.5"
   },
   "peerDependencies": {
     "@bedrock/core": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -24,9 +24,7 @@
     "url": "https://github.com/digitalbazaar/bedrock-views/issues"
   },
   "homepage": "https://github.com/digitalbazaar/bedrock-views",
-  "dependencies": {
-    "klona": "^2.0.5"
-  },
+  "dependencies": {},
   "peerDependencies": {
     "@bedrock/core": "^6.0.0",
     "@bedrock/express": "^8.0.0",


### PR DESCRIPTION
This PR builds on `remove-default-csrf` PR #73 and should be switched to main if that PR is merged first.