### PR TITLE
Remove `klona` dependency (use `structuredClone` instead).

### DIFF
--- a/lib/packages.js
+++ b/lib/packages.js
@@ -15,11 +15,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import * as bedrock from '@bedrock/core';
 import {createRequire} from 'node:module';
 import fs from 'node:fs';
-import {klona} from 'klona';
 import {logger} from './logger.js';
 import path from 'node:path';
 import '@bedrock/express';
@@ -57,7 +55,7 @@ export async function readPackages(rootModule) {
 
   // return cached packages
   if(_packageCache && _rootModule === rootModule) {
-    return klona(_packageCache);
+    return structuredClone(_packageCache);
   }
 
   logger.debug('Reading browser packages for "' + rootModule + '"...');

--- a/package.json
+++ b/package.json
@@ -24,9 +24,7 @@
     "url": "https://github.com/digitalbazaar/bedrock-views/issues"
   },
   "homepage": "https://github.com/digitalbazaar/bedrock-views",
-  "dependencies": {
-    "klona": "^2.0.5"
-  },
+  "dependencies": {},
   "peerDependencies": {
     "@bedrock/core": "^6.0.0",
     "@bedrock/express": "^8.0.0",


### PR DESCRIPTION
This PR builds on top of `remove-consolidate` PR #74 and should be retargeted to main if that other PR is merged first.